### PR TITLE
Fix image not display

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,4 +1,6 @@
 module PostsHelper
+  require 'nokogiri'
+
   def status_badges(status)
     badge = case status.to_sym
             when :draft
@@ -20,5 +22,23 @@ module PostsHelper
     end
 
     content_tag(:span, text, class:["badge", "badge-#{badge}"])
+  end
+
+  def render_action_text_with_images(content)
+    doc = Nokogiri::HTML::DocumentFragment.parse(content)
+
+    doc.css('action-text-attachment').each do |attachment_node|
+      url = attachment_node['url']
+      content_type = attachment_node['content-type']
+
+      if url.present? && content_type.match?(/^image\/.*/)
+        img_tag = ActionController::Base.helpers.image_tag(url)
+        attachment_node.replace(img_tag)
+      else
+        attachment_node.replace('Unsupported attachment')
+      end
+    end
+
+    doc.to_html.html_safe
   end
 end

--- a/app/views/user/posts/show.html.erb
+++ b/app/views/user/posts/show.html.erb
@@ -25,7 +25,7 @@
   <div class="container px-4 px-lg-5">
     <div class="row gx-4 gx-lg-5 justify-content-center">
       <div class="col-md-10 col-lg-8 col-xl-7">
-        <main class="trix-content site-main"><%= default_locale? ? @post['content']['body'].html_safe : @post['content_en']['body'].html_safe %></main>
+        <main class="trix-content site-main"><%= default_locale? ? render_action_text_with_images(@post['content']['body']) : render_action_text_with_images(@post['content_en']['body']) %></main>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Bug: After cache some image is not rendered
Reason: Action text save image as action-text-attachment instead of img tag
Fix: Replace action-text-attachment with img tag 