### PR TITLE
Add check when variable empty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,21 @@ jobs:
       - run:
           name: Calculate Coverage
           command: |
-            echo "Circle pull request: $CIRCLE_PULL_REQUEST"
-            if [ -z "$CIRCLE_PULL_REQUEST" ] && [ -z "$CIRCLE_PR_NUMBER" ]; then
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+              CIRCLE_PULL_REQUEST=`
+                curl -s -L \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Authorization: Bearer $GITHUB_TOKEN" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" \
+                  | grep -o '/pulls/[0-9]*' \
+                  | head -1 \
+                  | grep -o '[0-9]*' \
+                  || true
+              `
+            fi
+
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
               echo "Not a PR build. Skip coverage comment."
               exit 0
             fi


### PR DESCRIPTION
A [known issue](https://discuss.circleci.com/t/circle-pull-requests-environment-variable-not-being-set/29883/12) with CircleCI from long time ago. The CIRCLE_PULL_REQUEST is empty for the pr that newly created. 
Since CIRCLE_PULL_REQUEST itself is not reliable, an alternative solution is to query the pull request url using github api. 