### PR TITLE
Remove cron container memory limit

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,7 +66,6 @@ services:
       - internal
 
   cron:
-    mem_limit: 50m
     container_name: blog_cron
     image: blog_image:latest
     command: bash -c "whenever && whenever --update-crontab && sudo cron -f"


### PR DESCRIPTION
- Remove cron mem limit since it rarely use memory (only when run job). And when it does it use up to 300mb of RAM =)))